### PR TITLE
Make GitHub account dynamic in deployment pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,8 @@ steps:
   # Clone gh-pages version of the repository
   - bash: |
       set -e -x
-      git clone --branch gh-pages "git@github.com:k0ekk0ek/eclipse-cyclonedds.github.io" gh-pages
+      account=$(echo "${BUILD_REPOSITORY_URI}" | sed -n -E 's#^.*/([^/]+)/eclipse-cyclonedds.github.io(/.*)?$#\1#p')
+      git clone --branch gh-pages "git@github.com:${account}/eclipse-cyclonedds.github.io" gh-pages
       cd gh-pages
       ( [ "$(git branch --show-current)" = "gh-pages" ] ) || exit 1
     name: checkout_pages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ resources:
 # being added.
 #
 trigger: [ 'master' ]
+pr: none
 
 pool:
   vmImage: ubuntu-20.04


### PR DESCRIPTION
There's a stray URL in `azure-pipelines.yml` that points towards my own repository. This makes the GitHub user account dynamic so that it'll work for whoever forks (given that the other prerequisites are in place of course).