### PR TITLE
Include timestamp to invalidate GitHub Pages cache

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -5,18 +5,23 @@
 
 import os
 import re
+import pytz
+import datetime
 
+def timestamp():
+    timezone = pytz.timezone(TIMEZONE)
+    return timezone.localize(datetime.datetime.now())
 
 ABOUT = 'High performant and robust open source OMG DDS implementation'
 AUTHOR = 'Eclipse Cyclone DDS committers'
 SITENAME = 'Eclipse Cyclone DDS'
 SITEURL = 'https://cyclonedds.io'
+TIMEZONE = 'Europe/Paris'
+TIMESTAMP = timestamp()
 
 THEME = 'theme'
 PATH = 'content'
 STATIC_PATHS = [ 'images' ]
-
-TIMEZONE = 'Europe/Paris'
 
 DEFAULT_LANG = 'en'
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -115,7 +115,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "be4639be39d3a520e7ab654552c6e9f1273b926fc819714efb821bfd84a09308"
+content-hash = "6a885a536b00518ed23a4cbe7e602c54400150309b9429462a2f25b3729a861c"
 
 [metadata.files]
 blinker = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Eclipse Cyclone DDS committers"]
 [tool.poetry.dependencies]
 python = "^3.7"
 pelican = "^4.6.0"
+pytz = "^2021.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/theme/templates/partials/header.html
+++ b/theme/templates/partials/header.html
@@ -1,4 +1,5 @@
     <header class="navbar navbar-expand navbar-dark flex-column flex-md-row ato-navbar px-5">
+      <!-- Generated on {{ TIMESTAMP }} -->
       <a class="navbar-brand" href="/">
         <img src="/images/cyclonedds-white.svg" class="align-middle" alt="">
       </a>


### PR DESCRIPTION
For some reason https://cyclonedds.io isn't updated while https://eclipse-cyclonedds.github.io is. According to this Stack Overflow issue everything is updated if the html file are updated. Seems easiest to include a timestamp in the header so that it's always updated, whether it's a documentation build trigger or just a PR for the content.