### PR TITLE
Force invalidation of GitHub Pages cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,6 +118,7 @@ steps:
       set -e -x
       cd gh-pages
       git rm -rf *
+      git reset $(git rev-list --max-parents=0 --abbrev-commit HEAD)
       rm -rf *
       cp -a ../output/* ./
       cp -a ../CNAME ./
@@ -127,6 +128,10 @@ steps:
       git config --local user.email "azuredevops@microsoft.com"
       git commit --amend \
                  --message "Publish site from Azure Pipelines (${BUILD_BUILDNUMBER})" \
+                 --author "Azure Pipelines <azuredevops@microsoft.com>" \
+                 --date="$(date)"
+      git commit --message "Rebuild pages" \
+                 --author "Azure Pipelines <azuredevops@microsoft.com>" \
                  --date="$(date)"
       git push --force origin gh-pages
     name: commit_site


### PR DESCRIPTION
This PR cleans out the entire history for the `gh-pages` branch so the `CNAME` file is available from the first commit and adds one extra to (hopefully) force cache invalidation for cyclonedds.io.