### PR TITLE
Save README.md too

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,6 +117,7 @@ steps:
   - bash: |
       set -e -x
       cd gh-pages
+      cp -a README.md ../output/
       git rm -rf *
       rm -rf *
       cp -a ../output/* ./


### PR DESCRIPTION
This PR ensure all files in the first two commits are saved. The third commit in `gh-pages` is always amended to keep the repository from growing. Some background:

The way our site gets generated and published is on an orphaned branch in the git repository. Each refresh amends to avoid growing the repository indefinitely. I think it confused GitHub when the commit adding the CNAME file got overwritten. eclipse-cyclonedds.github.io got refreshed, but cyclonedds.io did not. After having looked at this for some time whithout success I decided to try recreating the branch. This unfortunately resulted in breaking the page all together.

I've recreated the `gh-pages` branch with the required CNAME file first and that commit will not dissapear, so it should work fine hereafter.