### PR TITLE
Correct regex to match two-digit versions

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -96,6 +96,4 @@ for project in PROJECTS:
         continue
     entries = os.listdir(path)
     for entry in entries:
-        # version must either be "latest" or "x.x.x"
-        if re.match('^((?i:latest)|\d+\.\d+\.\d+)$', entry):
-            PROJECTS[project]['releases'].append(entry)
+        PROJECTS[project]['releases'].append(entry)


### PR DESCRIPTION
This is how the versions are actually pushed from repo's. As you can see on the docs branch, folder 0.8 is present but if you go to the website the button is not present.