### PR TITLE
Rewrite https: origins to ssh

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,7 @@ steps:
         # push builders commit
         git config --local user.name "Azure Pipelines"
         git config --local user.email "azuredevops@microsoft.com"
+        git config --global --add url."git@github.com:".insteadOf "https://github.com/"
         git push
         # Let python tool handle the gh-pages sync
         ghp-import --no-jekyll --cname=cyclonedds.io --message="Azure build ${BUILD_BUILDNUMBER} for commit $(git rev-parse --verify HEAD)" --no-history --push --force --shell pages/


### PR DESCRIPTION
The git remote in CI is set to the https:// link instead of the ssh target. Through this I found a new git config tool I did not know about, you can dynamically rewrite remote urls! If the ssh key is indeed properly imported and has the correct rights (I assume it does) then this should be the last step to a working website rebuild. Fingers crossed!