### PR TITLE
Push with normal git client

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,8 @@ steps:
         git config --global --add url."git@github.com:".insteadOf "https://github.com/"
         git push
         # Let python tool handle the gh-pages sync
-        poetry run ghp-import --no-jekyll --cname=cyclonedds.io --message="Azure build ${BUILD_BUILDNUMBER} for commit $(git rev-parse --verify HEAD)" --no-history --push --force --shell pages/
+        poetry run ghp-import --no-jekyll --cname=cyclonedds.io --message="Azure build ${BUILD_BUILDNUMBER} for commit $(git rev-parse --verify HEAD)" --no-history pages/
+        git push -f origin gh-pages
       fi
     name: publish
     displayName: Publish


### PR DESCRIPTION
Reviewing the pipeline logs clearly something fishy is going on within ghp-import with respect to git settings. I reverted to using a normal git client for the push (but still set up the branch+commit correctly with ghp-import). I also finally went through the effort to replicate the website CI setup on my personal repo, which now works! I do _really_ think this is the last one now...