### PR TITLE
Follow variable changes in CXX

### DIFF
--- a/templates/code/cpp.conf.py
+++ b/templates/code/cpp.conf.py
@@ -40,3 +40,12 @@ breathe_projects = { "ddscxx_api_docs": "{{ doxygen_path }}" }
 breathe_default_project = "ddscxx_api_docs"
 breathe_show_define_initializer = True
 breathe_show_include = True
+
+rst_epilog = '\n'.join(map(lambda x: f".. |var-{x[0]}| replace:: {x[1]}", {
+    "project": "Eclipse Cyclone DDS: C++ Binding",
+    "project-short": "Cyclone DDS C++",
+    "core-project": "Eclipse Cyclone DDS",
+    "core-project-short": "Cyclone DDS"
+}.items()))
+
+


### PR DESCRIPTION
Follow the changes for using variables in the docs build (https://github.com/eclipse-cyclonedds/cyclonedds-cxx/pull/337).
The python version does not need changes since the conf.py is inherited.