### PR TITLE
Add release name for version 11.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,6 +26,7 @@
         }
     },
     "releases": {
+        "11.0": "Marche des Davidsbündler contre les Philistins",
         "0.10": "Lettres Dansantes",
         "0.9": "Papillons",
         "0.8": "Réplique"


### PR DESCRIPTION
This PR fixes the name of the 11.0 release on the website.

<img width="951" height="640" alt="Screenshot 2026-03-01 at 08 57 46" src="https://github.com/user-attachments/assets/8e64a892-e354-40e8-8520-c9728f46a55c" />

@eboasson could you have a look?